### PR TITLE
CFY-2133: Update server plugin

### DIFF
--- a/server_plugin/server.py
+++ b/server_plugin/server.py
@@ -106,11 +106,6 @@ def create_new_server(server_client):
 
     ctx.instance.runtime_properties[VSPHERE_SERVER_ID] = server._moId
 
-    public_ips = [server_client.get_server_ip(server, network['name'])
-                  for network in networks if network['external']]
-    if len(public_ips) == 1:
-        ctx.instance.runtime_properties[PUBLIC_IP] = public_ips[0]
-
 
 @operation
 @with_server_client
@@ -161,6 +156,8 @@ def delete(server_client, **kwargs):
 def get_state(server_client, **kwargs):
     server = get_server_by_context(server_client)
     if server_client.is_server_guest_running(server):
+        networking = ctx.node.properties.get('networking')
+        networks = networking.get('connect_networks', []) if networking else []
         ips = {}
         manager_network_ip = None
         management_networks = \
@@ -175,8 +172,15 @@ def get_state(server_client, **kwargs):
             network_name = network.network
             if management_network_name and \
                     (network_name == management_network_name):
-                manager_network_ip = network.ipAddress[0]
+                manager_network_ip = (network.ipAddress[0]
+                                      if len(network.ipAddress) > 0
+                                      else None)
+                ctx.logger.info("Server management ip address: {0}"
+                                .format(manager_network_ip))
+                if manager_network_ip is None:
+                    return False
             ips[network_name] = network.ipAddress[0]
+
         ctx.instance.runtime_properties['networks'] = ips
         ctx.instance.runtime_properties['ip'] = \
             (manager_network_ip
@@ -184,6 +188,17 @@ def get_state(server_client, **kwargs):
                  if len(server.guest.net) > 0
                  else None)
              )
+
+        public_ips = [server_client.get_server_ip(server, network['name'])
+                      for network in networks
+                      if network.get('external', False)]
+        if len(public_ips) == 1:
+            public_ip = public_ips[0]
+            ctx.logger.info("Server public ip address: {0}".format(public_ip))
+            if public_ip is None:
+                return False
+            ctx.instance.runtime_properties[PUBLIC_IP] = public_ips[0]
+
         return True
     return False
 

--- a/server_plugin/tests/test.py
+++ b/server_plugin/tests/test.py
@@ -110,6 +110,15 @@ class VsphereServerTest(TestCase):
         server_plugin.server.start()
         server = self.assert_server_exist_and_get(self.ctx.node.id)
         self.assert_server_started(server)
+
+        get_state_verified = False
+        for _ in range(WAIT_COUNT):
+            if server_plugin.server.get_state():
+                get_state_verified = True
+                break
+            time.sleep(WAIT_TIMEOUT)
+        self.assertTrue(get_state_verified)
+
         self.assertTrue(server_plugin.server.PUBLIC_IP
                         in self.ctx.instance.runtime_properties)
         ip = self.ctx.instance.runtime_properties[
@@ -170,17 +179,15 @@ class VsphereServerTest(TestCase):
         server_plugin.server.start()
         server = self.assert_server_exist_and_get(self.ctx.node.id)
         self.assert_server_started(server)
-        guest_is_running = False
 
+        get_state_verified = False
         for _ in range(WAIT_COUNT):
-            if self.is_server_guest_running(server):
-                guest_is_running = True
+            if server_plugin.server.get_state():
+                get_state_verified = True
                 break
             time.sleep(WAIT_TIMEOUT)
-        self.assertTrue(guest_is_running)
+        self.assertTrue(get_state_verified)
 
-        state = server_plugin.server.get_state()
-        self.assertTrue(state)
         self.assertTrue('networks' in self.ctx.instance.runtime_properties)
         self.assertTrue('ip' in self.ctx.instance.runtime_properties)
         ip_valid = True

--- a/vsphere_plugin_common/__init__.py
+++ b/vsphere_plugin_common/__init__.py
@@ -418,9 +418,12 @@ class ServerClient(VsphereClient):
         self._wait_for_task(task)
 
     def get_server_ip(self, vm, network_name):
+        server_ip = None
         for network in vm.guest.net:
-            if network_name.lower() == network.network.lower():
-                return network.ipAddress[0]
+            if network_name.lower() == network.network.lower()\
+                    and len(network.ipAddress) > 0:
+                server_ip = network.ipAddress[0]
+        return server_ip
 
     def _wait_vm_running(self, task):
         self._wait_for_task(task)


### PR DESCRIPTION
Move public ip processing to get_state.
Update get_state to trigger retry if
management ip or public ip is not yet
configured on guest OS.
Update get_server_ip method to return
None if interface doesn't have an ip.
