### PR TITLE
CFY-2147: Allow use of user created resource pools

### DIFF
--- a/vsphere_plugin_common/__init__.py
+++ b/vsphere_plugin_common/__init__.py
@@ -208,15 +208,15 @@ class ServerClient(VsphereClient):
         adaptermaps = []
 
         datacenter = self._get_obj_by_name([vim.Datacenter],
-                                           datacenter_name,
-                                           host.name,
-                                           recursive_parent=True)
+                                           datacenter_name)
         if datacenter is None:
             raise cfy_exc.NonRecoverableError(
                 "Datacenter {0} could not be found".format(datacenter_name))
 
         resource_pool = self._get_obj_by_name([vim.ResourcePool],
-                                              resource_pool_name)
+                                              resource_pool_name,
+                                              host.name if host else None,
+                                              recursive_parent=True)
         if resource_pool is None:
             raise cfy_exc.NonRecoverableError(
                 "Resource pool {0} could not be found"


### PR DESCRIPTION
When parenting on the host you can only use the default ones created by the system.

The error message has also been improved- this code was not trying to use network resource pools.
