### PR TITLE
CFY-2697: Fix vsphere_url to vsphere_host across plugin

### DIFF
--- a/examples/connection_config.json.example
+++ b/examples/connection_config.json.example
@@ -1,6 +1,6 @@
 {
     "username": "ENTER_VSPHERE_USERNAME",
     "password": "ENTER_VSPHERE_PASSWORD",
-    "url": "ENTER_VSPHERE_URL",
+    "host": "ENTER_VSPHERE_HOST",
     "port": 443
 }

--- a/manager_blueprint/inputs.yaml.template
+++ b/manager_blueprint/inputs.yaml.template
@@ -1,6 +1,6 @@
 vsphere_username: ''
 vsphere_password: ''
-vsphere_url: ''
+vsphere_host: ''
 vsphere_datacenter_name: ''
 manager_server_template: ''
 manager_server_cpus: ''

--- a/manager_blueprint/vsphere-manager-blueprint.yaml
+++ b/manager_blueprint/vsphere-manager-blueprint.yaml
@@ -17,9 +17,9 @@ inputs:
             vSphere user password
         type: string
 
-    vsphere_url:
+    vsphere_host:
         description: >
-            vSphere url
+            vSphere host
         type: string
 
     vsphere_port:
@@ -229,7 +229,7 @@ node_templates:
             connection_config:
                 username: { get_input: vsphere_username }
                 password: { get_input: vsphere_password }
-                url: { get_input: vsphere_url }
+                host: { get_input: vsphere_host }
                 port: { get_input: vsphere_port }
                 datacenter_name: { get_input: vsphere_datacenter_name }
                 resource_pool_name: { get_input: vsphere_resource_pool_name }

--- a/system_tests/vsphere_handler.py
+++ b/system_tests/vsphere_handler.py
@@ -94,8 +94,8 @@ class CloudifyVsphereInputsConfigReader(BaseCloudifyInputsConfigReader):
         return self.config['vsphere_datacenter_name']
 
     @property
-    def vsphere_url(self):
-        return self.config['vsphere_url']
+    def vsphere_host(self):
+        return self.config['vsphere_host']
 
     @property
     def management_network_name(self):
@@ -124,7 +124,7 @@ class VsphereHandler(BaseHandler):
             patch.append_value('manager_server_name', suffix)
 
     def get_vm(self, name):
-        vms = self.get_vm_by_name(self.env.vsphere_url,
+        vms = self.get_vm_by_name(self.env.vsphere_host,
                                   self.env.vsphere_username,
                                   self.env.vsphere_password,
                                   '443',

--- a/vsphere_plugin_common/__init__.py
+++ b/vsphere_plugin_common/__init__.py
@@ -114,12 +114,12 @@ class VsphereClient(object):
         return ret
 
     def connect(self, cfg):
-        url = cfg['url']
+        host = cfg['host']
         username = cfg['username']
         password = cfg['password']
         port = cfg['port']
         try:
-            self.si = SmartConnect(host=url,
+            self.si = SmartConnect(host=host,
                                    user=username,
                                    pwd=password,
                                    port=int(port))


### PR DESCRIPTION
Reasons:
- inconsistent use of attributes and terminology
  between vSphere API client and plugins`
  server deployment part: HOST vs URL

Changes:
- fixing vsphere_url to vsphere_host for consistency
