### PR TITLE
CFY-2725: Fix DuplicationError during VM provisioning

### DIFF
--- a/server_plugin/server.py
+++ b/server_plugin/server.py
@@ -231,4 +231,5 @@ def get_server_by_context(server_client):
     if VSPHERE_SERVER_ID in ctx.instance.runtime_properties:
         return server_client.get_server_by_id(
             ctx.instance.runtime_properties[VSPHERE_SERVER_ID])
-    return server_client.get_server_by_name(ctx.instance.id)
+    return server_client.get_server_by_name(
+        ctx.node.properties['server'].get('name', ctx.instance.id))


### PR DESCRIPTION
Reasons:
- if server provisioning failed due to certain reasons,
  but VM actually was provisioned, retry mechanis will
  try to re-run this task and will fail with duplication
  error since it tries to create VM with the same
  parameters as previous VM. In this case vSphere
  will raise exception: DuplicationError
- when create VM operation crashes with SSL timeout
  (from HTTPS protocol access to vSphere env), retry
  mechanism tries to execute this operation again
  (which seems to be ok), but operation doesn't
  check properly if VM already exist or not, and
  this cause Duplication error in vSphere environment.

Changes:
- improve look-up attribute from ctx.instance.id
  to ctx.node.properties['server'].get('name', ctx.instance.id)

Note. This fix would take manager_server_name input as look-up
      attribute (name is uniq according to vSphere API docs)
      and use defaul instance id if name is not there.
