### PR TITLE
Support deployment restrictions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@
   - Support restrictions on deployment location by setting one or more allowed hosts, clusters, or datastores.
   - Better logic for selecting deployment locations to ensure selected hosts have all required resources.
   - Improve health checks on hypervisors and datastores when determining availability for VM deployment.
+  - Remove defaults from plugin.yaml connection config to avoid them always overriding manager connection config.
 2.0.1:
   - Make naming of servers automatically replace underscores with hyphens, allowing nodecellar to work.
   - Don't fail when no public or management networks are set.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+2.1.0:
+  - Support restrictions on deployment location by setting one or more allowed hosts, clusters, or datastores.
+  - Better logic for selecting deployment locations to ensure selected hosts have all required resources.
+  - Improve health checks on hypervisors and datastores when determining availability for VM deployment.
 2.0.1:
   - Make naming of servers automatically replace underscores with hyphens, allowing nodecellar to work.
   - Don't fail when no public or management networks are set.

--- a/examples/blueprint.yaml.example
+++ b/examples/blueprint.yaml.example
@@ -2,7 +2,7 @@ tosca_definitions_version: cloudify_dsl_1_2
 
 imports:
     - http://www.getcloudify.org/spec/cloudify/3.3.1/types.yaml
-    - http://www.getcloudify.org/spec/vsphere-plugin/2.0.1/plugin.yaml
+    - http://www.getcloudify.org/spec/vsphere-plugin/2.1.0/plugin.yaml
 
 node_templates:
     example_server:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -6,8 +6,8 @@ plugins:
     vsphere:
         executor: central_deployment_agent
         package_name: cloudify-vsphere-plugin
-        package_version: '2.0.1'
-        source: https://github.com/cloudify-cosmo/cloudify-vsphere-plugin/archive/2.0.1.zip
+        package_version: '2.1.0'
+        source: https://github.com/cloudify-cosmo/cloudify-vsphere-plugin/archive/2.1.0.zip
 
 data_types:
     cloudify.datatypes.vsphere.Config:
@@ -109,6 +109,18 @@ node_types:
     cloudify.vsphere.nodes.Server:
         derived_from: cloudify.nodes.Compute
         properties:
+            allowed_hosts:
+                description: >
+                    Which ESX host(s) this server is allowed to be deployed on.
+                required: false
+            allowed_clusters:
+                description: >
+                    Which ESX cluster(s) this server is allowed to be deployed on.
+                required: false
+            allowed_datastores:
+                description: >
+                    Which ESX datastore(s) this server is allowed to be deployed on.
+                required: false
             server:
                 type: cloudify.datatypes.vsphere.ServerProperties
             networking:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -38,20 +38,17 @@ data_types:
                     Must be true if you are using clusters.
                 type: string
                 required: false
-                default: false
             resource_pool_name:
                 description: >
                     Name of a resource pool.
                     Defaults to Resources, which is a hidden resource pool on vSphere.
                 type: string
                 required: false
-                default: 'Resources'
             port:
                 description: >
                     vCenter port for SDK.
                 type: integer
                 required: false
-                default: 443
 
     cloudify.datatypes.vsphere.ServerProperties:
         properties:
@@ -126,7 +123,6 @@ node_types:
             networking:
                 type: cloudify.datatypes.vsphere.NetworkingProperties
             connection_config:
-                default: {}
                 type: cloudify.datatypes.vsphere.Config
         interfaces:
             cloudify.interfaces.lifecycle:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import setuptools
 setuptools.setup(
     zip_safe=True,
     name='cloudify-vsphere-plugin',
-    version='2.0.1',
+    version='2.1.0',
     packages=[
         'vsphere_plugin_common',
         'vsphere_server_plugin',

--- a/system_tests/resources/linux/double_storage-blueprint.yaml
+++ b/system_tests/resources/linux/double_storage-blueprint.yaml
@@ -95,7 +95,7 @@ node_templates:
     properties:
       install_agent: false
       server:
-        name: systemtestlinuxnaming
+        name: systemtestlinuxdoublestorage
         template: { get_input: template_name }
         cpus: 1
         memory: 2048

--- a/system_tests/resources/linux/fail-blueprint.yaml
+++ b/system_tests/resources/linux/fail-blueprint.yaml
@@ -9,22 +9,14 @@ inputs:
     description: >
       Template to clone VMs from
     default: WindowsServer2012R2ByCloudifyDefault
-  external_network:
-    description: >
-      Which external network to deploy the VM on
-    default: VM Network
-  external_network_distributed:
-    description: >
-      Whether the external network is on a distributed switch
-    default: true
   management_network:
     description: >
-      Which management network to deploy the VM on
-    default: VM Network
-  management_network_distributed:
+      Not used in this test, kept to simplify test code.
+    default: notused
+  external_network:
     description: >
-      Whether the management network is on a distributed switch
-    default: true
+      Not used in this test, kept to simplify test code.
+    default: notused
   vsphere_username:
     type: string
     description: >
@@ -61,6 +53,28 @@ inputs:
       signifies if server is to be automatically placed on a host
     default: false
     type: boolean
+  cpus:
+    description: >
+      How many CPUs to assign to the VM
+    default: 1
+    type: integer
+  memory:
+    description: >
+      How much memory to assign to the VM
+    default: 1024
+    type: integer
+  allowed_hosts:
+    description: >
+      Which hosts are allowed for deployment.
+    default: []
+  allowed_clusters:
+    description: >
+      Which clusters are allowed for deployment.
+    default: []
+  allowed_datastores:
+    description: >
+      Which datastores are allowed for deployment.
+    default: []
 
 node_types:
   connection_configuration:
@@ -81,18 +95,16 @@ node_templates:
         resource_pool_name: { get_input: vsphere_resource_pool_name }
         auto_placement: { get_input: vsphere_auto_placement }
 
-  testserver:
+  testserver1:
     type: cloudify.vsphere.nodes.Server
     properties:
       install_agent: false
+      allowed_hosts: { get_input: allowed_hosts }
+      allowed_clusters: { get_input: allowed_clusters }
+      allowed_datastores: { get_input: allowed_datastores }
       server:
-        name: systemtestlinuxnoexternalnet
+        name: systestfail
         template: { get_input: template_name }
-        cpus: 1
-        memory: 2048
-      networking:
-        connect_networks:
-          - name: { get_input: external_network }
-            switch_distributed: { get_input: external_network_distributed }
-            management: True
+        cpus: { get_input: cpus }
+        memory: { get_input: memory }
       connection_config: { get_property: [connection_configuration, connection_config] }

--- a/system_tests/resources/linux/no-interfaces-blueprint.yaml
+++ b/system_tests/resources/linux/no-interfaces-blueprint.yaml
@@ -86,7 +86,7 @@ node_templates:
     properties:
       install_agent: false
       server:
-        name: systemtestlinuxnaming
+        name: systemtestlinuxnointerfaces
         template: { get_input: template_name }
         cpus: 1
         memory: 2048

--- a/system_tests/resources/linux/no-management-net-blueprint.yaml
+++ b/system_tests/resources/linux/no-management-net-blueprint.yaml
@@ -86,7 +86,7 @@ node_templates:
     properties:
       install_agent: false
       server:
-        name: systemtestlinuxnaming
+        name: systemtestlinuxnomanagementnet
         template: { get_input: template_name }
         cpus: 1
         memory: 2048

--- a/system_tests/resources/linux/storage-blueprint.yaml
+++ b/system_tests/resources/linux/storage-blueprint.yaml
@@ -95,7 +95,7 @@ node_templates:
     properties:
       install_agent: false
       server:
-        name: systemtestlinuxnaming
+        name: systemtestlinuxstorage
         template: { get_input: template_name }
         cpus: 1
         memory: 2048

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ skipsdist = True
 [testenv]
 setenv =
         VIRTUAL_ENV={envdir}
-        UNIT_TESTS_CONFIG_PATH=../examples/unit_tests_config.yaml.example
-        CONNECTION_CONFIG_PATH=../examples/connection_config.yaml.example
+        UNIT_TESTS_CONFIG_PATH=examples/unit_tests_config.yaml.example
+        CONNECTION_CONFIG_PATH=examples/connection_config.yaml.example
 
 # NOTE: relative paths were used due to '-w' flag for nosetests util
 
@@ -23,7 +23,10 @@ commands =
 
 [testenv:py27]
 commands =
-    nosetests --with-cov -x -s -w vsphere_integration_tests
+    nosetests -v --nocapture --nologcapture --with-cov --cov-report term-missing --cov vsphere_server_plugin vsphere_server_plugin/tests
+    nosetests -v --nocapture --nologcapture --with-cov --cov-report term-missing --cov vsphere_network_plugin vsphere_network_plugin/tests
+    nosetests -v --nocapture --nologcapture --with-cov --cov-report term-missing --cov vsphere_storage_plugin vsphere_storage_plugin/tests
+    nosetests -v --nocapture --nologcapture --with-cov --cov-report term-missing --cov vsphere_plugin_common vsphere_plugin_common/tests
 
 [testenv:venv]
 commands = {posargs}

--- a/vsphere_network_plugin/tests/network_plugin_test.py
+++ b/vsphere_network_plugin/tests/network_plugin_test.py
@@ -19,7 +19,7 @@ import vsphere_plugin_common as vpc
 
 from cloudify import mocks as cfy_mocks
 from vsphere_network_plugin import network
-from vsphere_integration_tests import common as tests_common
+import vsphere_tests_common as tests_common
 
 _tests_config = tests_common.TestsConfig().get()
 network_test_config = _tests_config['network_test']

--- a/vsphere_plugin_common/tests/plugin_common_test.py
+++ b/vsphere_plugin_common/tests/plugin_common_test.py
@@ -1,0 +1,1797 @@
+#########
+# Copyright (c) 2014 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+
+from mock import Mock, patch, call
+import unittest
+
+from cloudify.exceptions import NonRecoverableError
+import vsphere_plugin_common
+
+
+class VspherePluginsCommonTests(unittest.TestCase):
+
+    def _make_mock_host(self,
+                        name='host',
+                        datastores=None,
+                        vms=None,
+                        memory=4096,
+                        cpus=4,
+                        networks=None,
+                        resource_pool=None,
+                        connected=True,
+                        status='green'):
+        host = Mock()
+        host.name = name
+        # Yes, datastore = datastores. See pyvmomi. (and vm->vms)
+        host.datastore = datastores or []
+        host.vm = vms or []
+        host.network = networks or []
+        host.hardware.memorySize = memory
+        host.hardware.cpuInfo.numCpuThreads = cpus
+        host.parent.resourcePool = resource_pool
+        host.overallStatus = status
+
+        if connected:
+            host.summary.runtime.connectionState = 'connected'
+        else:
+            host.summary.runtime.connectionState = 'disconnected'
+
+        return host
+
+    def _make_mock_network(self,
+                           name='network'):
+        network = Mock()
+        network.name = name
+
+        return network
+
+    def _make_mock_vm(self,
+                      name='vm',
+                      is_template=False,
+                      memory=1024,
+                      cpus=1,
+                      min_space=1024,
+                      extra_space=3072):
+        vm = Mock()
+        vm.name = name
+        vm.summary.config.template = is_template
+        vm.summary.config.memorySizeMB = memory
+        vm.summary.config.numCpu = cpus
+        vm.summary.storage.committed = min_space
+        vm.summary.storage.uncommitted = extra_space
+
+        return vm
+
+    def _make_mock_cluster(self, name):
+        cluster = Mock()
+        cluster.name = name
+
+        return cluster
+
+    def _make_mock_resource_pool(self,
+                                 name='resource_pool',
+                                 children=None):
+        resource_pool = Mock()
+        resource_pool.name = name
+        resource_pool.resourcePool = []
+
+        if children:
+            for child in children:
+                resource_pool.resourcePool.append(
+                    self._make_mock_resource_pool(
+                        **child
+                    )
+                )
+
+        return resource_pool
+
+    def _make_mock_datastore(self,
+                             name='datastore',
+                             status='green',
+                             accessible=True,
+                             free_space=4096):
+        datastore = Mock()
+        datastore.name = name
+        datastore.overallStatus = status
+        datastore.summary.accessible = accessible
+        datastore.summary.freeSpace = free_space
+
+        return datastore
+
+    @patch('vsphere_plugin_common.ServerClient.host_cpu_thread_usage_ratio')
+    @patch('vsphere_plugin_common.ServerClient.get_host_networks')
+    @patch('vsphere_plugin_common.ServerClient.get_host_resource_pools')
+    @patch('vsphere_plugin_common.ServerClient.get_host_free_memory')
+    @patch('vsphere_plugin_common.ServerClient.get_host_cluster_membership')
+    @patch('vsphere_plugin_common.ServerClient.host_is_usable')
+    @patch('vsphere_plugin_common.ServerClient.get_clusters')
+    @patch('vsphere_plugin_common.VsphereClient.get_obj_list')
+    @patch('vsphere_plugin_common.ctx')
+    def test_find_candidate_hosts_one_host_unusable(self,
+                                                    mock_ctx,
+                                                    mock_get_obj_list,
+                                                    mock_get_clusters,
+                                                    mock_host_is_usable,
+                                                    mock_cluster_membership,
+                                                    mock_get_free_memory,
+                                                    mock_get_resource_pools,
+                                                    mock_get_networks,
+                                                    mock_get_cpu_ratio):
+        mock_host_is_usable.side_effect = (False, True, True)
+        host_names = ('see', 'hear', 'speak')
+        hosts = [
+            self._make_mock_host(name)
+            for name in host_names
+        ]
+        mock_get_obj_list.return_value = hosts
+        intended_memory = 1024
+        mock_get_free_memory.return_value = intended_memory
+        intended_resource_pool = 'rp'
+        mock_get_resource_pools.return_value = [
+            self._make_mock_resource_pool(name)
+            for name in [intended_resource_pool]
+        ]
+        intended_nets = [
+            {'name': 'say', 'switch_distributed': True},
+            {'name': 'wave', 'switch_distributed': False},
+        ]
+        mock_get_networks.return_value = intended_nets
+        intended_cpus = 1
+        mock_get_cpu_ratio.return_value = 1.0
+
+        client = vsphere_plugin_common.ServerClient()
+
+        expected_result = [hosts[1], hosts[2]]
+
+        result = client.find_candidate_hosts(
+            resource_pool=intended_resource_pool,
+            vm_cpus=intended_cpus,
+            vm_memory=intended_memory,
+            vm_networks=intended_nets,
+            allowed_hosts=None,
+            allowed_clusters=None,
+        )
+
+        mock_ctx.logger.warn.assert_called_once_with(
+            'Host {host} not usable due to health status.'.format(
+                host=host_names[0],
+            ),
+        )
+        self.assertEqual(
+            mock_host_is_usable.mock_calls,
+            [call(host) for host in hosts],
+        )
+        self.assertEqual(
+            mock_get_free_memory.mock_calls,
+            [call(host) for host in (hosts[1], hosts[2])],
+        )
+        self.assertEqual(
+            mock_get_resource_pools.mock_calls,
+            [call(host) for host in (hosts[1], hosts[2])],
+        )
+        self.assertEqual(
+            mock_get_networks.mock_calls,
+            [call(host) for host in (hosts[1], hosts[2])],
+        )
+        self.assertEqual(
+            mock_get_cpu_ratio.mock_calls,
+            [call(host, intended_cpus)
+             for host in (hosts[1], hosts[2])],
+        )
+
+        # No clusters should mean no membership checks
+        self.assertEqual(mock_get_clusters.call_count, 0)
+        self.assertEqual(mock_cluster_membership.call_count, 0)
+
+        self.assertEqual(result, expected_result)
+
+    @patch('vsphere_plugin_common.ServerClient.host_cpu_thread_usage_ratio')
+    @patch('vsphere_plugin_common.ServerClient.get_host_networks')
+    @patch('vsphere_plugin_common.ServerClient.get_host_resource_pools')
+    @patch('vsphere_plugin_common.ServerClient.get_host_free_memory')
+    @patch('vsphere_plugin_common.ServerClient.get_host_cluster_membership')
+    @patch('vsphere_plugin_common.ServerClient.host_is_usable')
+    @patch('vsphere_plugin_common.ServerClient.get_clusters')
+    @patch('vsphere_plugin_common.VsphereClient.get_obj_list')
+    @patch('vsphere_plugin_common.ctx')
+    def test_find_candidate_hosts_allowed_clusters(self,
+                                                   mock_ctx,
+                                                   mock_get_obj_list,
+                                                   mock_get_clusters,
+                                                   mock_host_is_usable,
+                                                   mock_cluster_membership,
+                                                   mock_get_free_memory,
+                                                   mock_get_resource_pools,
+                                                   mock_get_networks,
+                                                   mock_get_cpu_ratio):
+        mock_host_is_usable.return_value = True
+        host_names = ('see', 'hear', 'speak')
+        hosts = [
+            self._make_mock_host(name)
+            for name in host_names
+        ]
+        mock_get_obj_list.return_value = hosts
+        intended_memory = 1024
+        mock_get_free_memory.return_value = intended_memory
+        intended_resource_pool = 'rp'
+        mock_get_resource_pools.return_value = [
+            self._make_mock_resource_pool(name)
+            for name in [intended_resource_pool]
+        ]
+        intended_nets = [
+            {'name': 'say', 'switch_distributed': True},
+            {'name': 'wave', 'switch_distributed': False},
+        ]
+        mock_get_networks.return_value = intended_nets
+        intended_cpus = 1
+        mock_get_cpu_ratio.return_value = 1.0
+        wrong_cluster = 'fake cluster'
+        mock_cluster_membership.side_effect = (
+            None,
+            wrong_cluster,
+            'testcluster',
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        expected_result = [hosts[2]]
+
+        result = client.find_candidate_hosts(
+            resource_pool=intended_resource_pool,
+            vm_cpus=intended_cpus,
+            vm_memory=intended_memory,
+            vm_networks=intended_nets,
+            allowed_hosts=None,
+            allowed_clusters=['testcluster'],
+        )
+
+        self.assertEqual(
+            mock_ctx.logger.warn.mock_calls,
+            [
+                call(
+                    'Host {host} is not in a cluster, '
+                    'and allowed clusters have been set.'.format(
+                        host=host_names[0],
+                    )
+                ),
+                call(
+                    'Host {host} is in cluster {cluster}, '
+                    'which is not an allowed cluster.'.format(
+                        host=host_names[1],
+                        cluster=wrong_cluster,
+                    )
+                ),
+            ],
+        )
+        self.assertEqual(
+            mock_host_is_usable.mock_calls,
+            [call(host) for host in hosts],
+        )
+        self.assertEqual(
+            mock_cluster_membership.mock_calls,
+            [call(host) for host in hosts],
+        )
+        mock_get_free_memory.assert_called_once_with(hosts[2])
+        mock_get_resource_pools.assert_called_once_with(hosts[2])
+        mock_get_networks.assert_called_once_with(hosts[2])
+        mock_get_cpu_ratio.assert_called_once_with(hosts[2], intended_cpus)
+
+        mock_get_clusters.assert_called_once_with()
+
+        self.assertEqual(result, expected_result)
+
+    @patch('vsphere_plugin_common.ServerClient.host_cpu_thread_usage_ratio')
+    @patch('vsphere_plugin_common.ServerClient.get_host_networks')
+    @patch('vsphere_plugin_common.ServerClient.get_host_resource_pools')
+    @patch('vsphere_plugin_common.ServerClient.get_host_free_memory')
+    @patch('vsphere_plugin_common.ServerClient.get_host_cluster_membership')
+    @patch('vsphere_plugin_common.ServerClient.host_is_usable')
+    @patch('vsphere_plugin_common.ServerClient.get_clusters')
+    @patch('vsphere_plugin_common.VsphereClient.get_obj_list')
+    @patch('vsphere_plugin_common.ctx')
+    def test_find_candidate_hosts_insufficient_memory(self,
+                                                      mock_ctx,
+                                                      mock_get_obj_list,
+                                                      mock_get_clusters,
+                                                      mock_host_is_usable,
+                                                      mock_cluster_membership,
+                                                      mock_get_free_memory,
+                                                      mock_get_resource_pools,
+                                                      mock_get_networks,
+                                                      mock_get_cpu_ratio):
+        mock_host_is_usable.return_value = True
+        host_names = ('see', 'hear', 'speak')
+        hosts = [
+            self._make_mock_host(name)
+            for name in host_names
+        ]
+        mock_get_obj_list.return_value = hosts
+        intended_memory = 1024
+        mock_get_free_memory.side_effect = (
+            intended_memory - 1,
+            intended_memory,
+            intended_memory,
+        )
+        intended_resource_pool = 'rp'
+        mock_get_resource_pools.return_value = [
+            self._make_mock_resource_pool(name)
+            for name in [intended_resource_pool]
+        ]
+        intended_nets = [
+            {'name': 'say', 'switch_distributed': True},
+            {'name': 'wave', 'switch_distributed': False},
+        ]
+        mock_get_networks.return_value = intended_nets
+        intended_cpus = 1
+        mock_get_cpu_ratio.return_value = 1.0
+
+        client = vsphere_plugin_common.ServerClient()
+
+        expected_result = [hosts[1], hosts[2]]
+
+        result = client.find_candidate_hosts(
+            resource_pool=intended_resource_pool,
+            vm_cpus=intended_cpus,
+            vm_memory=intended_memory,
+            vm_networks=intended_nets,
+            allowed_hosts=None,
+            allowed_clusters=None,
+        )
+
+        mock_ctx.logger.warn.assert_called_once_with(
+            'Host {host} does not have enough free memory.'.format(
+                host=host_names[0],
+            ),
+        )
+        self.assertEqual(
+            mock_host_is_usable.mock_calls,
+            [call(host) for host in hosts],
+        )
+        self.assertEqual(
+            mock_get_free_memory.mock_calls,
+            [call(host) for host in hosts],
+        )
+        self.assertEqual(
+            mock_get_resource_pools.mock_calls,
+            [call(host) for host in (hosts[1], hosts[2])],
+        )
+        self.assertEqual(
+            mock_get_networks.mock_calls,
+            [call(host) for host in (hosts[1], hosts[2])],
+        )
+        self.assertEqual(
+            mock_get_cpu_ratio.mock_calls,
+            [call(host, intended_cpus)
+             for host in (hosts[1], hosts[2])],
+        )
+
+        # No clusters should mean no membership checks
+        self.assertEqual(mock_get_clusters.call_count, 0)
+        self.assertEqual(mock_cluster_membership.call_count, 0)
+
+        self.assertEqual(result, expected_result)
+
+    @patch('vsphere_plugin_common.ServerClient.host_cpu_thread_usage_ratio')
+    @patch('vsphere_plugin_common.ServerClient.get_host_networks')
+    @patch('vsphere_plugin_common.ServerClient.get_host_resource_pools')
+    @patch('vsphere_plugin_common.ServerClient.get_host_free_memory')
+    @patch('vsphere_plugin_common.ServerClient.get_host_cluster_membership')
+    @patch('vsphere_plugin_common.ServerClient.host_is_usable')
+    @patch('vsphere_plugin_common.ServerClient.get_clusters')
+    @patch('vsphere_plugin_common.VsphereClient.get_obj_list')
+    @patch('vsphere_plugin_common.ctx')
+    def test_find_candidate_hosts_bad_networks(self,
+                                               mock_ctx,
+                                               mock_get_obj_list,
+                                               mock_get_clusters,
+                                               mock_host_is_usable,
+                                               mock_cluster_membership,
+                                               mock_get_free_memory,
+                                               mock_get_resource_pools,
+                                               mock_get_networks,
+                                               mock_get_cpu_ratio):
+        mock_host_is_usable.return_value = True
+        host_names = ('see', 'hear', 'speak', 'celebrate')
+        hosts = [
+            self._make_mock_host(name)
+            for name in host_names
+        ]
+        mock_get_obj_list.return_value = hosts
+        intended_memory = 1024
+        mock_get_free_memory.return_value = intended_memory
+        intended_resource_pool = 'rp'
+        mock_get_resource_pools.return_value = [
+            self._make_mock_resource_pool(name)
+            for name in [intended_resource_pool]
+        ]
+        intended_nets = [
+            {'name': 'say', 'switch_distributed': True},
+            {'name': 'wave', 'switch_distributed': False},
+        ]
+        mock_get_networks.side_effect = (
+            [intended_nets[0]],
+            [intended_nets[1]],
+            [],
+            intended_nets,
+        )
+        intended_cpus = 1
+        mock_get_cpu_ratio.return_value = 1.0
+
+        client = vsphere_plugin_common.ServerClient()
+
+        expected_result = [hosts[3]]
+
+        result = client.find_candidate_hosts(
+            resource_pool=intended_resource_pool,
+            vm_cpus=intended_cpus,
+            vm_memory=intended_memory,
+            vm_networks=intended_nets,
+            allowed_hosts=None,
+            allowed_clusters=None,
+        )
+
+        self.assertEqual(
+            mock_ctx.logger.warn.mock_calls,
+            [
+                call(
+                    'Host {host} does not have all required networks. '
+                    'Missing standard networks: {net}. '.format(
+                        host=host_names[0],
+                        net=intended_nets[1]['name'],
+                    )
+                ),
+                call(
+                    'Host {host} does not have all required networks. '
+                    'Missing distributed networks: {net}. '.format(
+                        host=host_names[1],
+                        net=intended_nets[0]['name'],
+                    )
+                ),
+                call(
+                    'Host {host} does not have all required networks. '
+                    'Missing standard networks: {net1}. '
+                    'Missing distributed networks: {net2}. '.format(
+                        host=host_names[2],
+                        net1=intended_nets[1]['name'],
+                        net2=intended_nets[0]['name'],
+                    )
+                ),
+            ],
+        )
+
+        self.assertEqual(
+            mock_host_is_usable.mock_calls,
+            [call(host) for host in hosts],
+        )
+        self.assertEqual(
+            mock_get_free_memory.mock_calls,
+            [call(host) for host in hosts],
+        )
+        self.assertEqual(
+            mock_get_resource_pools.mock_calls,
+            [call(host) for host in hosts],
+        )
+        self.assertEqual(
+            mock_get_networks.mock_calls,
+            [call(host) for host in hosts],
+        )
+        mock_get_cpu_ratio.assert_called_once_with(hosts[3], intended_cpus)
+
+        # No clusters should mean no membership checks
+        self.assertEqual(mock_get_clusters.call_count, 0)
+        self.assertEqual(mock_cluster_membership.call_count, 0)
+
+        self.assertEqual(result, expected_result)
+
+    @patch('vsphere_plugin_common.ServerClient.host_cpu_thread_usage_ratio')
+    @patch('vsphere_plugin_common.ServerClient.get_host_networks')
+    @patch('vsphere_plugin_common.ServerClient.get_host_resource_pools')
+    @patch('vsphere_plugin_common.ServerClient.get_host_free_memory')
+    @patch('vsphere_plugin_common.ServerClient.get_host_cluster_membership')
+    @patch('vsphere_plugin_common.ServerClient.host_is_usable')
+    @patch('vsphere_plugin_common.ServerClient.get_clusters')
+    @patch('vsphere_plugin_common.VsphereClient.get_obj_list')
+    @patch('vsphere_plugin_common.ctx')
+    def test_find_candidate_hosts_all_unusable(self,
+                                               mock_ctx,
+                                               mock_get_obj_list,
+                                               mock_get_clusters,
+                                               mock_host_is_usable,
+                                               mock_cluster_membership,
+                                               mock_get_free_memory,
+                                               mock_get_resource_pools,
+                                               mock_get_networks,
+                                               mock_get_cpu_ratio):
+        mock_host_is_usable.return_value = False
+        host_names = ('see', 'hear', 'speak')
+        hosts = [
+            self._make_mock_host(name)
+            for name in host_names
+        ]
+        mock_get_obj_list.return_value = hosts
+
+        client = vsphere_plugin_common.ServerClient()
+
+        # Using try/except pattern because some plugins are using testtool,
+        # which doesn't support the context aware assertRaises so maintaining
+        # consistency in this fashion until standardisation.
+        try:
+            client.find_candidate_hosts(
+                resource_pool='rp',
+                vm_cpus=1,
+                vm_memory=1024,
+                vm_networks=[],
+                allowed_hosts=None,
+                allowed_clusters=None,
+            )
+        except NonRecoverableError as err:
+            assert 'No healthy hosts' in str(err)
+
+        self.assertEqual(
+            mock_ctx.logger.warn.mock_calls,
+            [
+                call(
+                    'Host {host} not usable due to health status.'.format(
+                        host=host,
+                    )
+                )
+                for host in host_names
+            ],
+        )
+        self.assertEqual(
+            mock_host_is_usable.mock_calls,
+            [call(host) for host in hosts],
+        )
+        self.assertEqual(
+            mock_get_free_memory.call_count,
+            0,
+        )
+        self.assertEqual(
+            mock_get_resource_pools.call_count,
+            0,
+        )
+        self.assertEqual(
+            mock_get_networks.call_count,
+            0,
+        )
+        self.assertEqual(
+            mock_get_cpu_ratio.call_count,
+            0
+        )
+
+        # No clusters should mean no membership checks
+        self.assertEqual(mock_get_clusters.call_count, 0)
+        self.assertEqual(mock_cluster_membership.call_count, 0)
+
+    @patch('vsphere_plugin_common.ServerClient.host_cpu_thread_usage_ratio')
+    @patch('vsphere_plugin_common.ServerClient.get_host_networks')
+    @patch('vsphere_plugin_common.ServerClient.get_host_resource_pools')
+    @patch('vsphere_plugin_common.ServerClient.get_host_free_memory')
+    @patch('vsphere_plugin_common.ServerClient.get_host_cluster_membership')
+    @patch('vsphere_plugin_common.ServerClient.host_is_usable')
+    @patch('vsphere_plugin_common.ServerClient.get_clusters')
+    @patch('vsphere_plugin_common.VsphereClient.get_obj_list')
+    @patch('vsphere_plugin_common.ctx')
+    def test_find_candidate_hosts_no_allowed_usable(self,
+                                                    mock_ctx,
+                                                    mock_get_obj_list,
+                                                    mock_get_clusters,
+                                                    mock_host_is_usable,
+                                                    mock_cluster_membership,
+                                                    mock_get_free_memory,
+                                                    mock_get_resource_pools,
+                                                    mock_get_networks,
+                                                    mock_get_cpu_ratio):
+        mock_host_is_usable.return_value = False
+        host_names = ('see', 'hear', 'speak')
+        allowed_hosts = [host_names[0]]
+        hosts = [
+            self._make_mock_host(name)
+            for name in host_names
+        ]
+        mock_get_obj_list.return_value = hosts
+
+        client = vsphere_plugin_common.ServerClient()
+
+        # Using try/except pattern because some plugins are using testtool,
+        # which doesn't support the context aware assertRaises so maintaining
+        # consistency in this fashion until standardisation.
+        try:
+            client.find_candidate_hosts(
+                resource_pool='rp',
+                vm_cpus=1,
+                vm_memory=1024,
+                vm_networks=[],
+                allowed_hosts=allowed_hosts,
+                allowed_clusters=None,
+            )
+        except NonRecoverableError as err:
+            assert 'No healthy hosts' in str(err)
+            assert "Only these hosts" in str(err)
+            assert ', '.join(allowed_hosts) in str(err)
+
+        mock_ctx.logger.warn.assert_called_once_with(
+            'Host {host} not usable due to health status.'.format(
+                host=host_names[0],
+            ),
+        )
+        mock_host_is_usable.assert_called_once_with(hosts[0])
+        self.assertEqual(
+            mock_get_free_memory.call_count,
+            0,
+        )
+        self.assertEqual(
+            mock_get_resource_pools.call_count,
+            0,
+        )
+        self.assertEqual(
+            mock_get_networks.call_count,
+            0,
+        )
+        self.assertEqual(
+            mock_get_cpu_ratio.call_count,
+            0
+        )
+
+        # No clusters should mean no membership checks
+        self.assertEqual(mock_get_clusters.call_count, 0)
+        self.assertEqual(mock_cluster_membership.call_count, 0)
+
+    @patch('vsphere_plugin_common.ServerClient.host_cpu_thread_usage_ratio')
+    @patch('vsphere_plugin_common.ServerClient.get_host_networks')
+    @patch('vsphere_plugin_common.ServerClient.get_host_resource_pools')
+    @patch('vsphere_plugin_common.ServerClient.get_host_free_memory')
+    @patch('vsphere_plugin_common.ServerClient.get_host_cluster_membership')
+    @patch('vsphere_plugin_common.ServerClient.host_is_usable')
+    @patch('vsphere_plugin_common.ServerClient.get_clusters')
+    @patch('vsphere_plugin_common.VsphereClient.get_obj_list')
+    @patch('vsphere_plugin_common.ctx')
+    def test_find_candidate_hosts_no_usable_clusters(self,
+                                                     mock_ctx,
+                                                     mock_get_obj_list,
+                                                     mock_get_clusters,
+                                                     mock_host_is_usable,
+                                                     mock_cluster_membership,
+                                                     mock_get_free_memory,
+                                                     mock_get_resource_pools,
+                                                     mock_get_networks,
+                                                     mock_get_cpu_ratio):
+        mock_host_is_usable.return_value = False
+        host_names = ('see', 'hear', 'speak')
+        hosts = [
+            self._make_mock_host(name)
+            for name in host_names
+        ]
+        mock_get_obj_list.return_value = hosts
+
+        client = vsphere_plugin_common.ServerClient()
+
+        allowed_clusters = ['hello', 'goodbye']
+        mock_cluster_membership.return_value = allowed_clusters[0]
+
+        # Using try/except pattern because some plugins are using testtool,
+        # which doesn't support the context aware assertRaises so maintaining
+        # consistency in this fashion until standardisation.
+        try:
+            client.find_candidate_hosts(
+                resource_pool='rp',
+                vm_cpus=1,
+                vm_memory=1024,
+                vm_networks=[],
+                allowed_hosts=None,
+                allowed_clusters=allowed_clusters,
+            )
+        except NonRecoverableError as err:
+            assert 'No healthy hosts' in str(err)
+            assert "Only hosts in these clusters" in str(err)
+            assert ', '.join(allowed_clusters) in str(err)
+
+        self.assertEqual(
+            mock_ctx.logger.warn.mock_calls,
+            [
+                call(
+                    'Host {host} not usable due to health status.'.format(
+                        host=host,
+                    )
+                )
+                for host in host_names
+            ],
+        )
+        self.assertEqual(
+            mock_host_is_usable.mock_calls,
+            [call(host) for host in hosts],
+        )
+        self.assertEqual(
+            mock_get_free_memory.call_count,
+            0,
+        )
+        self.assertEqual(
+            mock_get_resource_pools.call_count,
+            0,
+        )
+        self.assertEqual(
+            mock_get_networks.call_count,
+            0,
+        )
+        self.assertEqual(
+            mock_get_cpu_ratio.call_count,
+            0
+        )
+        mock_get_clusters.assert_called_once_with()
+
+        # Unhealthy hosts should not be subject to membership checks
+        self.assertEqual(mock_cluster_membership.call_count, 0)
+
+    @patch('vsphere_plugin_common.ServerClient.host_cpu_thread_usage_ratio')
+    @patch('vsphere_plugin_common.ServerClient.get_host_networks')
+    @patch('vsphere_plugin_common.ServerClient.get_host_resource_pools')
+    @patch('vsphere_plugin_common.ServerClient.get_host_free_memory')
+    @patch('vsphere_plugin_common.ServerClient.get_host_cluster_membership')
+    @patch('vsphere_plugin_common.ServerClient.host_is_usable')
+    @patch('vsphere_plugin_common.ServerClient.get_clusters')
+    @patch('vsphere_plugin_common.VsphereClient.get_obj_list')
+    @patch('vsphere_plugin_common.ctx')
+    def test_find_candidate_hosts_bad_cluster_hosts(self,
+                                                    mock_ctx,
+                                                    mock_get_obj_list,
+                                                    mock_get_clusters,
+                                                    mock_host_is_usable,
+                                                    mock_cluster_membership,
+                                                    mock_get_free_memory,
+                                                    mock_get_resource_pools,
+                                                    mock_get_networks,
+                                                    mock_get_cpu_ratio):
+        mock_host_is_usable.return_value = False
+        host_names = ('see', 'hear', 'speak')
+        allowed_hosts = [host_names[2]]
+        hosts = [
+            self._make_mock_host(name)
+            for name in host_names
+        ]
+        mock_get_obj_list.return_value = hosts
+
+        client = vsphere_plugin_common.ServerClient()
+
+        allowed_clusters = ['hello', 'goodbye']
+        mock_cluster_membership.return_value = 'see_cluster'
+
+        # Using try/except pattern because some plugins are using testtool,
+        # which doesn't support the context aware assertRaises so maintaining
+        # consistency in this fashion until standardisation.
+        try:
+            client.find_candidate_hosts(
+                resource_pool='rp',
+                vm_cpus=1,
+                vm_memory=1024,
+                vm_networks=[],
+                allowed_hosts=allowed_hosts,
+                allowed_clusters=allowed_clusters,
+            )
+        except NonRecoverableError as err:
+            assert 'No healthy hosts' in str(err)
+            assert "Only hosts in these clusters" in str(err)
+            assert ', '.join(allowed_clusters) in str(err)
+            assert "Only these hosts" in str(err)
+            assert ', '.join(allowed_hosts) in str(err)
+
+        mock_ctx.logger.warn.assert_called_once_with(
+            'Host {host} not usable due to health status.'.format(
+                host=allowed_hosts[0],
+            )
+        )
+        mock_host_is_usable.assert_called_once_with(hosts[2])
+        self.assertEqual(
+            mock_get_free_memory.call_count,
+            0,
+        )
+        self.assertEqual(
+            mock_get_resource_pools.call_count,
+            0,
+        )
+        self.assertEqual(
+            mock_get_networks.call_count,
+            0,
+        )
+        self.assertEqual(
+            mock_get_cpu_ratio.call_count,
+            0
+        )
+        mock_get_clusters.assert_called_once_with()
+
+        # Unhealthy hosts should not be subject to membership checks
+        self.assertEqual(mock_cluster_membership.call_count, 0)
+
+    @patch('vsphere_plugin_common.ServerClient.get_host_resource_pools')
+    def test_get_resource_pool_exists(self, mock_get_host_resource_pools):
+        pool_name = 'mypool'
+        host_pools = [
+            self._make_mock_resource_pool(name)
+            for name in (pool_name, 'this', 'that')
+        ]
+        mock_get_host_resource_pools.return_value = host_pools
+
+        host = self._make_mock_host('myhost')
+
+        expected = host_pools[0]
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client.get_resource_pool(host, pool_name)
+
+        self.assertEqual(result, expected)
+
+        mock_get_host_resource_pools.assert_called_once_with(host)
+
+    @patch('vsphere_plugin_common.ServerClient.get_host_resource_pools')
+    def test_get_resource_pool_fail(self, mock_get_host_resource_pools):
+        pool_name = 'mypool'
+        pools = ('this', 'that')
+        host_pools = [
+            self._make_mock_resource_pool(name)
+            for name in pools
+        ]
+        mock_get_host_resource_pools.return_value = host_pools
+
+        host = self._make_mock_host('myhost')
+
+        client = vsphere_plugin_common.ServerClient()
+
+        try:
+            client.get_resource_pool(host, pool_name)
+        except NonRecoverableError as err:
+            missing = 'Resource pool {pool} not found on host {host}'.format(
+                pool=pool_name,
+                host=host.name,
+            )
+            assert missing in str(err)
+            assert ', '.join(pools) in str(err)
+
+        mock_get_host_resource_pools.assert_called_once_with(host)
+
+    @patch('vsphere_plugin_common.ServerClient.calculate_datastore_weighting')
+    @patch('vsphere_plugin_common.ServerClient.datastore_is_usable')
+    @patch('vsphere_plugin_common.ServerClient.get_datastores')
+    @patch('vsphere_plugin_common.ctx')
+    def test_select_host_and_datastore_none_allowed(
+        self,
+        mock_ctx,
+        mock_get_datastores,
+        mock_datastore_is_usable,
+        mock_datastore_weighting,
+    ):
+        hosts = [
+            self._make_mock_host(
+                name='host1',
+                datastores=[
+                    self._make_mock_datastore(
+                        name='mydatastore',
+                    )
+                ],
+            ),
+        ]
+        template = self._make_mock_vm(name='mytemplate')
+        allowed_datastores = ['none at all', 'except this one']
+
+        client = vsphere_plugin_common.ServerClient()
+
+        try:
+            client.select_host_and_datastore(
+                candidate_hosts=hosts,
+                vm_memory=1024,
+                template=template,
+                allowed_datastores=allowed_datastores,
+            )
+        except NonRecoverableError as err:
+            assert 'No datastores found' in str(err)
+            assert 'Only these datastores were allowed' in str(err)
+            assert ', '.join(allowed_datastores) in str(err)
+            assert ', '.join(host.name for host in hosts)
+
+        mock_ctx.logger.warn.assert_called_once_with(
+            'Host {host} had no allowed datastores.'.format(
+                host=hosts[0].name,
+            )
+        )
+        self.assertEqual(mock_datastore_is_usable.call_count, 0)
+        self.assertEqual(mock_datastore_weighting.call_count, 0)
+        mock_get_datastores.assert_called_once_with()
+
+    @patch('vsphere_plugin_common.ServerClient.calculate_datastore_weighting')
+    @patch('vsphere_plugin_common.ServerClient.datastore_is_usable')
+    @patch('vsphere_plugin_common.ServerClient.get_datastores')
+    @patch('vsphere_plugin_common.ctx')
+    def test_select_host_and_datastore_none_usable(
+        self,
+        mock_ctx,
+        mock_get_datastores,
+        mock_datastore_is_usable,
+        mock_datastore_weighting,
+    ):
+        hosts = [
+            self._make_mock_host(
+                name='host1',
+                datastores=[
+                    self._make_mock_datastore(
+                        name='mydatastore',
+                    )
+                ],
+            ),
+        ]
+        mock_datastore_is_usable.return_value = False
+        template = self._make_mock_vm(name='mytemplate')
+
+        client = vsphere_plugin_common.ServerClient()
+
+        try:
+            client.select_host_and_datastore(
+                candidate_hosts=hosts,
+                vm_memory=1024,
+                template=template,
+                allowed_datastores=None,
+            )
+        except NonRecoverableError as err:
+            assert 'No datastores found' in str(err)
+            assert ', '.join(host.name for host in hosts)
+            assert 'Only these datastores were allowed' not in str(err)
+
+        self.assertEqual(
+            mock_ctx.logger.warn.mock_calls,
+            [
+                call(
+                    'Excluding datastore {ds} on host {host} as it is not '
+                    'healthy.'.format(
+                        ds=hosts[0].datastore[0].name,
+                        host=hosts[0].name,
+                    ),
+                ),
+                call(
+                    'Host {host} has no usable datastores.'.format(
+                        host=hosts[0].name,
+                    ),
+                ),
+            ],
+        )
+        mock_datastore_is_usable.assert_called_once_with(
+            hosts[0].datastore[0],
+        )
+        self.assertEqual(mock_datastore_weighting.call_count, 0)
+
+    @patch('vsphere_plugin_common.ServerClient.calculate_datastore_weighting')
+    @patch('vsphere_plugin_common.ServerClient.datastore_is_usable')
+    @patch('vsphere_plugin_common.ServerClient.get_datastores')
+    @patch('vsphere_plugin_common.ctx')
+    def test_select_host_and_datastore_insufficient_space(
+        self,
+        mock_ctx,
+        mock_get_datastores,
+        mock_datastore_is_usable,
+        mock_datastore_weighting,
+    ):
+        hosts = [
+            self._make_mock_host(
+                name='host1',
+                datastores=[
+                    self._make_mock_datastore(
+                        name='mydatastore',
+                    )
+                ],
+            ),
+        ]
+        mock_datastore_is_usable.return_value = True
+        template = self._make_mock_vm(name='mytemplate')
+        mock_datastore_weighting.return_value = None
+
+        memory = 1024
+        client = vsphere_plugin_common.ServerClient()
+
+        try:
+            client.select_host_and_datastore(
+                candidate_hosts=hosts,
+                vm_memory=memory,
+                template=template,
+                allowed_datastores=None,
+            )
+        except NonRecoverableError as err:
+            assert 'No datastores found' in str(err)
+            assert ', '.join(host.name for host in hosts)
+            assert 'Only these datastores were allowed' not in str(err)
+
+        mock_ctx.logger.warn.assert_called_once_with(
+            'Datastore {ds} on host {host} does not have enough free '
+            'space.'.format(
+                ds=hosts[0].datastore[0].name,
+                host=hosts[0].name,
+            ),
+        )
+        mock_datastore_is_usable.assert_called_once_with(
+            hosts[0].datastore[0],
+        )
+        mock_datastore_weighting.assert_called_once_with(
+            datastore=hosts[0].datastore[0],
+            vm_memory=memory,
+            template=template,
+        )
+
+    @patch('vsphere_plugin_common.ServerClient.calculate_datastore_weighting')
+    @patch('vsphere_plugin_common.ServerClient.datastore_is_usable')
+    @patch('vsphere_plugin_common.ServerClient.get_datastores')
+    @patch('vsphere_plugin_common.ctx')
+    def test_select_host_and_datastore_use_allowed(
+        self,
+        mock_ctx,
+        mock_get_datastores,
+        mock_datastore_is_usable,
+        mock_datastore_weighting,
+    ):
+        right_datastore = self._make_mock_datastore(
+            name='mydatastore',
+        )
+        wrong_datastore = self._make_mock_datastore(
+            name='notthisone',
+        )
+        right_host = self._make_mock_host(
+            name='host2',
+            datastores=[
+                right_datastore,
+                wrong_datastore,
+            ],
+        )
+        hosts = [
+            self._make_mock_host(
+                name='host1',
+                datastores=[wrong_datastore],
+            ),
+            right_host,
+            self._make_mock_host(
+                name='host3',
+                datastores=[wrong_datastore],
+            ),
+        ]
+        mock_datastore_is_usable.return_value = True
+        template = self._make_mock_vm(name='mytemplate')
+        mock_datastore_weighting.return_value = 1
+
+        memory = 1024
+        allowed_datastores = [right_datastore.name]
+
+        client = vsphere_plugin_common.ServerClient()
+
+        expected = right_host, right_datastore
+
+        result = client.select_host_and_datastore(
+            candidate_hosts=hosts,
+            vm_memory=memory,
+            template=template,
+            allowed_datastores=allowed_datastores,
+        )
+
+        self.assertEqual(result, expected)
+
+        mock_datastore_is_usable.assert_called_once_with(right_datastore)
+        mock_datastore_weighting.assert_called_once_with(
+            datastore=right_datastore,
+            vm_memory=memory,
+            template=template,
+        )
+
+    @patch('vsphere_plugin_common.ServerClient.calculate_datastore_weighting')
+    @patch('vsphere_plugin_common.ServerClient.datastore_is_usable')
+    @patch('vsphere_plugin_common.ServerClient.get_datastores')
+    @patch('vsphere_plugin_common.ctx')
+    def test_select_host_and_datastore_use_best_ds_on_best_host_if_possible(
+        self,
+        mock_ctx,
+        mock_get_datastores,
+        mock_datastore_is_usable,
+        mock_datastore_weighting,
+    ):
+        right_datastore = self._make_mock_datastore(
+            name='mydatastore',
+        )
+        wrong_datastore = self._make_mock_datastore(
+            name='notthisone',
+        )
+        right_host = self._make_mock_host(
+            name='host2',
+            datastores=[
+                wrong_datastore,
+                right_datastore,
+            ],
+        )
+        hosts = [
+            right_host,
+            self._make_mock_host(
+                name='host1',
+                datastores=[wrong_datastore],
+            ),
+        ]
+        mock_datastore_is_usable.return_value = True
+        template = self._make_mock_vm(name='mytemplate')
+        mock_datastore_weighting.side_effect = (1, 100, 1000)
+
+        memory = 1024
+
+        client = vsphere_plugin_common.ServerClient()
+
+        expected = right_host, right_datastore
+
+        result = client.select_host_and_datastore(
+            candidate_hosts=hosts,
+            vm_memory=memory,
+            template=template,
+            allowed_datastores=None,
+        )
+
+        self.assertEqual(result, expected)
+
+        self.assertEqual(
+            mock_datastore_is_usable.mock_calls,
+            [
+                call(wrong_datastore),
+                call(right_datastore),
+                call(wrong_datastore),
+            ],
+        )
+        self.assertEqual(
+            mock_datastore_weighting.mock_calls,
+            [
+                call(
+                    datastore=wrong_datastore,
+                    vm_memory=memory,
+                    template=template,
+                ),
+                call(
+                    datastore=right_datastore,
+                    vm_memory=memory,
+                    template=template,
+                ),
+                call(
+                    datastore=wrong_datastore,
+                    vm_memory=memory,
+                    template=template,
+                ),
+            ],
+        )
+
+    @patch('vsphere_plugin_common.ServerClient.calculate_datastore_weighting')
+    @patch('vsphere_plugin_common.ServerClient.datastore_is_usable')
+    @patch('vsphere_plugin_common.ServerClient.get_datastores')
+    @patch('vsphere_plugin_common.ctx')
+    def test_select_host_and_datastore_use_best_host_if_all_poor_datastores(
+        self,
+        mock_ctx,
+        mock_get_datastores,
+        mock_datastore_is_usable,
+        mock_datastore_weighting,
+    ):
+        right_datastore = self._make_mock_datastore(
+            name='mydatastore',
+        )
+        wrong_datastore = self._make_mock_datastore(
+            name='notthisone',
+        )
+        right_host = self._make_mock_host(
+            name='host2',
+            datastores=[
+                wrong_datastore,
+                right_datastore,
+            ],
+        )
+        hosts = [
+            right_host,
+            self._make_mock_host(
+                name='host1',
+                datastores=[wrong_datastore],
+            ),
+        ]
+        mock_datastore_is_usable.return_value = True
+        template = self._make_mock_vm(name='mytemplate')
+        mock_datastore_weighting.side_effect = (-100, -2, -1)
+
+        memory = 1024
+
+        client = vsphere_plugin_common.ServerClient()
+
+        expected = right_host, right_datastore
+
+        result = client.select_host_and_datastore(
+            candidate_hosts=hosts,
+            vm_memory=memory,
+            template=template,
+            allowed_datastores=None,
+        )
+
+        self.assertEqual(result, expected)
+
+        self.assertEqual(
+            mock_datastore_is_usable.mock_calls,
+            [
+                call(wrong_datastore),
+                call(right_datastore),
+                call(wrong_datastore),
+            ],
+        )
+        self.assertEqual(
+            mock_datastore_weighting.mock_calls,
+            [
+                call(
+                    datastore=wrong_datastore,
+                    vm_memory=memory,
+                    template=template,
+                ),
+                call(
+                    datastore=right_datastore,
+                    vm_memory=memory,
+                    template=template,
+                ),
+                call(
+                    datastore=wrong_datastore,
+                    vm_memory=memory,
+                    template=template,
+                ),
+            ],
+        )
+
+    @patch('vsphere_plugin_common.ServerClient.calculate_datastore_weighting')
+    @patch('vsphere_plugin_common.ServerClient.datastore_is_usable')
+    @patch('vsphere_plugin_common.ServerClient.get_datastores')
+    @patch('vsphere_plugin_common.ctx')
+    def test_select_host_and_datastore_use_best_datastore_if_current_poor(
+        self,
+        mock_ctx,
+        mock_get_datastores,
+        mock_datastore_is_usable,
+        mock_datastore_weighting,
+    ):
+        right_datastore = self._make_mock_datastore(
+            name='mydatastore',
+        )
+        wrong_datastore = self._make_mock_datastore(
+            name='notthisone',
+        )
+        right_host = self._make_mock_host(
+            name='host2',
+            datastores=[
+                wrong_datastore,
+                right_datastore,
+            ],
+        )
+        hosts = [
+            self._make_mock_host(
+                name='host1',
+                datastores=[wrong_datastore],
+            ),
+            right_host,
+        ]
+        mock_datastore_is_usable.return_value = True
+        template = self._make_mock_vm(name='mytemplate')
+        mock_datastore_weighting.side_effect = (-100, -2, 1)
+
+        memory = 1024
+
+        client = vsphere_plugin_common.ServerClient()
+
+        expected = right_host, right_datastore
+
+        result = client.select_host_and_datastore(
+            candidate_hosts=hosts,
+            vm_memory=memory,
+            template=template,
+            allowed_datastores=None,
+        )
+
+        self.assertEqual(result, expected)
+
+        self.assertEqual(
+            mock_datastore_is_usable.mock_calls,
+            [
+                call(wrong_datastore),
+                call(wrong_datastore),
+                call(right_datastore),
+            ],
+        )
+        self.assertEqual(
+            mock_datastore_weighting.mock_calls,
+            [
+                call(
+                    datastore=wrong_datastore,
+                    vm_memory=memory,
+                    template=template,
+                ),
+                call(
+                    datastore=wrong_datastore,
+                    vm_memory=memory,
+                    template=template,
+                ),
+                call(
+                    datastore=right_datastore,
+                    vm_memory=memory,
+                    template=template,
+                ),
+            ],
+        )
+
+    def test_get_host_free_memory_no_vms(self):
+        expected = 12345
+        host = self._make_mock_host(memory=expected)
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client.get_host_free_memory(host)
+
+        self.assertEqual(result, expected)
+
+    def test_get_host_free_memory_with_vms(self):
+        vm1_mem = 10
+        vm2_mem = 894
+        host_mem = 12345
+        expected = host_mem - vm1_mem - vm2_mem
+
+        vms = [
+            self._make_mock_vm(memory=vm1_mem),
+            self._make_mock_vm(memory=vm2_mem),
+        ]
+        host = self._make_mock_host(
+            memory=host_mem,
+            vms=vms,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client.get_host_free_memory(host)
+
+        self.assertEqual(result, expected)
+
+    def test_host_cpu_thread_usage_ratio_no_vms(self):
+        host_cpus = 4
+        new_vm_cpus = 4
+        expected = float(host_cpus) / new_vm_cpus
+
+        host = self._make_mock_host(
+            cpus=host_cpus,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client.host_cpu_thread_usage_ratio(
+            host=host,
+            vm_cpus=new_vm_cpus,
+        )
+
+        self.assertEqual(result, expected)
+
+    def test_host_cpu_thread_usage_ratio_with_vms(self):
+        host_cpus = 4
+        new_vm_cpus = 4
+        vm1_cpus = 2
+        vm2_cpus = 4
+
+        existing_vms = [
+            self._make_mock_vm(cpus=vm1_cpus),
+            self._make_mock_vm(cpus=vm2_cpus),
+        ]
+
+        total_cpus = vm1_cpus + vm2_cpus + new_vm_cpus
+
+        expected = float(host_cpus) / total_cpus
+
+        host = self._make_mock_host(
+            cpus=host_cpus,
+            vms=existing_vms,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client.host_cpu_thread_usage_ratio(
+            host=host,
+            vm_cpus=new_vm_cpus,
+        )
+
+        self.assertEqual(result, expected)
+
+    @patch('vsphere_plugin_common.vim.ManagedEntity.Status')
+    def test_datastore_is_usable_good(self, mock_status):
+        mock_status.green = 'green'
+
+        datastore = self._make_mock_datastore(
+            status=mock_status.green,
+            accessible=True,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        self.assertTrue(client.datastore_is_usable(datastore))
+
+    @patch('vsphere_plugin_common.vim.ManagedEntity.Status')
+    def test_datastore_is_usable_mostly_good(self, mock_status):
+        mock_status.yellow = 'yellow'
+
+        datastore = self._make_mock_datastore(
+            status=mock_status.yellow,
+            accessible=True,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        self.assertTrue(client.datastore_is_usable(datastore))
+
+    @patch('vsphere_plugin_common.vim.ManagedEntity.Status')
+    def test_datastore_is_usable_good_but_disconnected(self, mock_status):
+        datastore = self._make_mock_datastore(
+            accessible=False,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        self.assertFalse(client.datastore_is_usable(datastore))
+
+    @patch('vsphere_plugin_common.vim.ManagedEntity.Status')
+    def test_datastore_is_usable_not_good(self, mock_status):
+        datastore = self._make_mock_datastore(
+            status='something different',
+            accessible=True,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        self.assertFalse(client.datastore_is_usable(datastore))
+
+    def test_calculate_datastore_weighting_insufficient_space(self):
+        datastore = self._make_mock_datastore(
+            free_space=0,
+        )
+
+        template = self._make_mock_vm(
+            is_template=True,
+            min_space=10,
+            extra_space=10,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client.calculate_datastore_weighting(
+            datastore=datastore,
+            template=template,
+            vm_memory=10,
+        )
+
+        self.assertIsNone(result)
+
+    def test_calculate_datastore_weighting_minimum(self):
+        # Bare minimum should be memory (in bytes, we specify in MB)
+        # + minimum space used by template
+        initial_free = 10485770
+        datastore = self._make_mock_datastore(
+            free_space=initial_free,
+        )
+        vm_memory = 10
+        min_space = 10
+        extra_space = 1000000
+
+        expected_weighting = initial_free - (vm_memory * 1024 * 1024)
+        expected_weighting = expected_weighting - min_space - extra_space
+
+        template = self._make_mock_vm(
+            is_template=True,
+            min_space=min_space,
+            extra_space=extra_space,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client.calculate_datastore_weighting(
+            datastore=datastore,
+            template=template,
+            vm_memory=vm_memory,
+        )
+
+        self.assertEqual(result, expected_weighting)
+
+    def test_calculate_datastore_weighting_more_than_enough(self):
+        initial_free = 17179869184
+        datastore = self._make_mock_datastore(
+            free_space=initial_free,
+        )
+        vm_memory = 10
+        min_space = 10
+        extra_space = 10
+
+        expected_weighting = initial_free - (vm_memory * 1024 * 1024)
+        expected_weighting = expected_weighting - min_space - extra_space
+
+        template = self._make_mock_vm(
+            is_template=True,
+            min_space=min_space,
+            extra_space=extra_space,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client.calculate_datastore_weighting(
+            datastore=datastore,
+            template=template,
+            vm_memory=vm_memory,
+        )
+
+        self.assertEqual(result, expected_weighting)
+
+    def test_recurse_resource_pools_no_children(self):
+        pool_name = 'pool1'
+        expected = []
+        pool = self._make_mock_resource_pool(
+            name=pool_name,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client.recurse_resource_pools(pool)
+
+        self.assertEqual(result, expected)
+
+    def test_recurse_resource_pools_with_children(self):
+        pool1_name = 'pool1'
+        pool2_name = 'something'
+        pool3_name = 'yes'
+        pool4_name = 'scell'
+        pool5_name = 'shwg'
+
+        pool = self._make_mock_resource_pool(
+            name=pool1_name,
+            children=[
+                {
+                    'name': pool2_name,
+                },
+                {
+                    'name': pool3_name,
+                    'children': [
+                        {
+                            'name': pool4_name,
+                        },
+                        {
+                            'name': pool5_name,
+                        },
+                    ],
+                },
+            ],
+        )
+
+        expected = [
+            pool.resourcePool[0],
+            pool.resourcePool[1],
+            pool.resourcePool[1].resourcePool[0],
+            pool.resourcePool[1].resourcePool[1],
+        ]
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client.recurse_resource_pools(pool)
+
+        # We should have the same in each list, but order is unimportant
+        expected.sort()
+        result.sort()
+
+        self.assertEqual(result, expected)
+
+    @patch('vsphere_plugin_common.ServerClient._port_group_is_distributed')
+    def test_get_host_networks(self, mock_is_distributed):
+        net_names = ('say', 'hello', 'wave', 'goodybe')
+        net_distributed = (True, False, True, True)
+        mock_is_distributed.side_effect = net_distributed
+
+        expected = [
+            {
+                'name': net[0],
+                'switch_distributed': net[1],
+            }
+            for net in zip(net_names, net_distributed)
+        ]
+
+        nets = [
+            self._make_mock_network(name=net)
+            for net in net_names
+        ]
+
+        host = self._make_mock_host(networks=nets)
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client.get_host_networks(host)
+
+        self.assertEqual(result, expected)
+
+    @patch('vsphere_plugin_common.ServerClient.recurse_resource_pools')
+    def test_get_host_resource_pools_no_children(self, mock_recurse):
+        mock_recurse.return_value = []
+
+        base_pool = self._make_mock_resource_pool(name='Resources')
+
+        expected = [base_pool]
+
+        host = self._make_mock_host(resource_pool=base_pool)
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client.get_host_resource_pools(host)
+
+        self.assertEqual(result, expected)
+
+    @patch('vsphere_plugin_common.ServerClient.recurse_resource_pools')
+    def test_get_host_resource_pools_with_children(self, mock_recurse):
+        other_pools = [
+            self._make_mock_resource_pool(),
+            self._make_mock_resource_pool(),
+            self._make_mock_resource_pool(),
+        ]
+        mock_recurse.return_value = other_pools
+        base_pool = self._make_mock_resource_pool(name='Resources')
+
+        expected = [base_pool]
+        expected.extend(other_pools)
+
+        host = self._make_mock_host(resource_pool=base_pool)
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client.get_host_resource_pools(host)
+
+        self.assertEqual(result, expected)
+
+    @patch('vsphere_plugin_common.vim.ClusterComputeResource')
+    @patch('vsphere_plugin_common.VsphereClient.get_obj_list')
+    def test_get_clusters(self, mock_get_obj, mock_cluster_type):
+        client = vsphere_plugin_common.ServerClient()
+
+        client.get_clusters()
+
+        mock_get_obj.assert_called_once_with([mock_cluster_type])
+
+    @patch('vsphere_plugin_common.vim.Datastore')
+    @patch('vsphere_plugin_common.VsphereClient.get_obj_list')
+    def test_get_datastores(self, mock_get_obj, mock_datastore_type):
+        client = vsphere_plugin_common.ServerClient()
+
+        client.get_datastores()
+
+        mock_get_obj.assert_called_once_with([mock_datastore_type])
+
+    @patch('vsphere_plugin_common.vim.ClusterComputeResource')
+    @patch('vsphere_plugin_common.isinstance', create=True)
+    def test_get_host_cluster_membership_member(self,
+                                                mock_isinstance,
+                                                mock_cluster_type):
+        expected_name = 'mycluster'
+        host = self._make_mock_host()
+        host.parent.name = expected_name
+
+        mock_isinstance.return_value = True
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client.get_host_cluster_membership(host)
+
+        mock_isinstance.assert_called_once_with(
+            host.parent,
+            mock_cluster_type,
+        )
+
+        self.assertEqual(expected_name, result)
+
+    @patch('vsphere_plugin_common.vim.ClusterComputeResource')
+    @patch('vsphere_plugin_common.isinstance', create=True)
+    def test_get_host_cluster_membership_non_member(self,
+                                                    mock_isinstance,
+                                                    mock_cluster_type):
+        host = self._make_mock_host()
+
+        mock_isinstance.return_value = False
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client.get_host_cluster_membership(host)
+
+        mock_isinstance.assert_called_once_with(
+            host.parent,
+            mock_cluster_type,
+        )
+
+        self.assertIsNone(result)
+
+    @patch('vsphere_plugin_common.vim.ManagedEntity.Status')
+    def test_host_is_usable_good(self, mock_status):
+        mock_status.green = 'green'
+
+        host = self._make_mock_host(
+            status=mock_status.green,
+            connected=True,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        self.assertTrue(client.host_is_usable(host))
+
+    @patch('vsphere_plugin_common.vim.ManagedEntity.Status')
+    def test_host_is_usable_mostly_good(self, mock_status):
+        mock_status.yellow = 'yellow'
+
+        host = self._make_mock_host(
+            status=mock_status.yellow,
+            connected=True,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        self.assertTrue(client.host_is_usable(host))
+
+    @patch('vsphere_plugin_common.vim.ManagedEntity.Status')
+    def test_host_is_usable_good_but_disconnected(self, mock_status):
+        mock_status.green = 'green'
+
+        host = self._make_mock_host(
+            status=mock_status.green,
+            connected=False,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        self.assertFalse(client.host_is_usable(host))
+
+    @patch('vsphere_plugin_common.vim.ManagedEntity.Status')
+    def test_host_is_usable_mostly_good_but_disconnected(self, mock_status):
+        mock_status.yellow = 'yellow'
+
+        host = self._make_mock_host(
+            status=mock_status.yellow,
+            connected=False,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        self.assertFalse(client.host_is_usable(host))
+
+    @patch('vsphere_plugin_common.vim.ManagedEntity.Status')
+    def test_host_is_usable_not_good(self, mock_status):
+        mock_status.other = 'something'
+
+        host = self._make_mock_host(
+            status=mock_status.other,
+            connected=True,
+        )
+
+        client = vsphere_plugin_common.ServerClient()
+
+        self.assertFalse(client.host_is_usable(host))
+
+    @patch('vsphere_plugin_common.vim.dvs.DistributedVirtualPortgroup')
+    @patch('vsphere_plugin_common.isinstance', create=True)
+    def test_port_group_is_distributed(self,
+                                       mock_isinstance,
+                                       mock_distributed_port_group_type):
+        # While isinstance returns True/False, this is a quicker way to be
+        # explicit in our expectations that we see the result it returns.
+        expected = 'what isinstance said'
+        port_group = Mock()
+
+        mock_isinstance.return_value = expected
+
+        client = vsphere_plugin_common.ServerClient()
+
+        result = client._port_group_is_distributed(port_group)
+
+        mock_isinstance.assert_called_once_with(
+            port_group,
+            mock_distributed_port_group_type,
+        )
+
+        self.assertEqual(expected, result)

--- a/vsphere_server_plugin/server.py
+++ b/vsphere_server_plugin/server.py
@@ -105,6 +105,16 @@ def create_new_server(server_client):
     dns_servers = None
     networking = ctx.node.properties.get('networking')
 
+    allowed_hosts = ctx.node.properties.get('allowed_hosts')
+    if isinstance(allowed_hosts, basestring):
+        allowed_hosts = [allowed_hosts]
+    allowed_clusters = ctx.node.properties.get('allowed_clusters')
+    if isinstance(allowed_clusters, basestring):
+        allowed_clusters = [allowed_clusters]
+    allowed_datastores = ctx.node.properties.get('allowed_datastores')
+    if isinstance(allowed_datastores, basestring):
+        allowed_datastores = [allowed_datastores]
+
     # This should be debug, but left as info until CFY-4867 makes logs more
     # visible
     ctx.logger.info(
@@ -188,7 +198,10 @@ def create_new_server(server_client):
                                          vm_name,
                                          os_type,
                                          domain,
-                                         dns_servers)
+                                         dns_servers,
+                                         allowed_hosts,
+                                         allowed_clusters,
+                                         allowed_datastores)
     ctx.logger.info('Successfully created server called {name}'.format(
                     name=vm_name))
     ctx.instance.runtime_properties[VSPHERE_SERVER_ID] = server._moId

--- a/vsphere_server_plugin/tests/server_plugin_test.py
+++ b/vsphere_server_plugin/tests/server_plugin_test.py
@@ -18,7 +18,7 @@ import socket
 import time
 import unittest
 
-from vsphere_integration_tests import common as tests_common
+import vsphere_tests_common as tests_common
 
 from cloudify import mocks
 from vsphere_server_plugin import server as server_plugin

--- a/vsphere_storage_plugin/tests/storage_plugin_test.py
+++ b/vsphere_storage_plugin/tests/storage_plugin_test.py
@@ -23,7 +23,7 @@ from cloudify import mocks
 
 from vsphere_server_plugin import server as server_plugin
 from vsphere_storage_plugin import storage as storage_plugin
-from vsphere_integration_tests import common as tests_common
+import vsphere_tests_common as tests_common
 
 _tests_config = tests_common.TestsConfig().get()
 storage_config = _tests_config['storage_test']

--- a/vsphere_tests_common/__init__.py
+++ b/vsphere_tests_common/__init__.py
@@ -53,6 +53,9 @@ class TestCase(unittest.TestCase):
         self.logger.debug("VSphere provider test setUp() done")
 
     def tearDown(self):
+        # TODO: Remove all of this, or move it somewhere more sensible.
+        # This file claims to be running unit tests, so it should not be
+        # making any connections to the outside world.
         self.logger.debug("VSphere provider test tearDown() called")
         # Compute
         self.logger.debug("Check are there any server to delete")


### PR DESCRIPTION
Addresses the following issues:
https://cloudifysource.atlassian.net/browse/CFY-2415 (allow specifying particular hypervisors on which to deploy)
https://cloudifysource.atlassian.net/browse/CFY-2805 (allow specifying particular clusters on which to deploy)
https://cloudifysource.atlassian.net/browse/CFY-2704 (allow specifying particular datastores on which to deploy)
https://github.com/cloudify-cosmo/cloudify-vsphere-plugin/issues/62 (don't deploy to hosts which don't have specified resource pool)
https://cloudifysource.atlassian.net/browse/CFY-5890 (don't try to deploy on disconnected datastores)
https://cloudifysource.atlassian.net/browse/CFY-5337 (don't try to deploy on disconnected hosts NB: Does not fix the issue of trying to deploy on unlicensed/license-expired hosts)
https://cloudifysource.atlassian.net/browse/CFY-1281 (improve error messages when hosts cannot be used)