### PR TITLE
VSPHERE-97 correctly handle slashes in network names

### DIFF
--- a/system_tests/test_vsphere_local_blueprints/local_linux_test.py
+++ b/system_tests/test_vsphere_local_blueprints/local_linux_test.py
@@ -537,8 +537,8 @@ class VsphereLocalLinuxTest(TestCase):
         if net_name:
             inputs['test_network_name'] = net_name
         elif 'test_network_name' in self.env.cloudify_config.keys():
-                inputs['test_network_name'] = self.env.cloudify_config[
-                    'test_network_name']
+            inputs['test_network_name'] = self.env.cloudify_config[
+                'test_network_name']
 
         self.network_env = local.init_env(
             blueprint,

--- a/vsphere_plugin_common/__init__.py
+++ b/vsphere_plugin_common/__init__.py
@@ -2279,7 +2279,8 @@ class ServerClient(VsphereClient):
                 continue
             if (
                 network.network and
-                network_name.lower() == network.network.lower() and
+                network_name.lower() == self._get_normalised_name(
+                    network.network.lower()) and
                 len(network.ipAddress) > 0
             ):
                 ip_address = get_ip_from_vsphere_nic_ips(network)

--- a/vsphere_plugin_common/tests/plugin_common_test.py
+++ b/vsphere_plugin_common/tests/plugin_common_test.py
@@ -2638,3 +2638,41 @@ class VspherePluginCommonFSTests(fake_filesystem_unittest.TestCase):
             ret = config.get()
 
         self.assertEqual({'some': 'contents'}, ret)
+
+
+class PluginCommonUnitTests(unittest.TestCase):
+
+    @patch('vsphere_plugin_common.get_ip_from_vsphere_nic_ips')
+    def test_get_server_ip(self, get_ip_from_nic_mock):
+        client = vsphere_plugin_common.ServerClient()
+        server = Mock()
+        server.guest.net = [
+            MagicMock(name='oobly'),
+            MagicMock(name='hoobly'),
+        ]
+        server.guest.net[0].network = 'oobly'
+        server.guest.net[0].ipAddress = '10.11.12.13'
+        server.guest.net[1].network = 'hoobly'
+        server.guest.net[1].ipAddress = '10.11.12.14'
+
+        res = client.get_server_ip(server, 'hoobly')
+
+        self.assertEqual(
+            get_ip_from_nic_mock.return_value,
+            res)
+
+    @patch('vsphere_plugin_common.get_ip_from_vsphere_nic_ips')
+    def test_get_server_ip_with_slash(self, get_ip_from_nic_mock):
+        client = vsphere_plugin_common.ServerClient()
+        server = Mock()
+        server.guest.net = [
+            MagicMock(name='oobly/hoobly'),
+        ]
+        server.guest.net[0].network = 'oobly%2fhoobly'
+        server.guest.net[0].ipAddress = '10.11.12.13'
+
+        res = client.get_server_ip(server, 'oobly/hoobly')
+
+        self.assertEqual(
+            get_ip_from_nic_mock.return_value,
+            res)


### PR DESCRIPTION
When looking up IP addresses in `get_state`