### PR TITLE
Fix to cluster name pulling from host hypervisor

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -7,7 +7,7 @@ plugins:
   vsphere:
     executor: central_deployment_agent
     package_name: cloudify-vsphere-plugin
-    package_version: '2.8.0'
+    package_version: '2.8.1'
     source: https://github.com/cloudify-cosmo/cloudify-vsphere-plugin/archive/2.8.0.zip
 
 data_types:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import setuptools
 setuptools.setup(
     zip_safe=True,
     name='cloudify-vsphere-plugin',
-    version='2.8.0',
+    version='2.8.1',
     packages=[
         'vsphere_plugin_common',
         'vsphere_server_plugin',

--- a/vsphere_plugin_common/__init__.py
+++ b/vsphere_plugin_common/__init__.py
@@ -2290,7 +2290,7 @@ class ServerClient(VsphereClient):
             Return the name of the cluster this host is part of,
             or None if it is not part of a cluster.
         """
-        if isinstance(host.parent, vim.ClusterComputeResource):
+        if isinstance(host.parent, vim.ClusterComputeResource) or isinstance(host.parent.obj, vim.ClusterComputeResource):
             return host.parent.name
         else:
             return None


### PR DESCRIPTION
Plugin couldn't find cluster that would fit when _allowed_clusters_ property was set, because _get_host_membership()_ returned _None_ for most of the hosts.
While the returned value from host.parent was:
_cluster(resourcePool=resource_pool(name='Resources', resourcePool=[], id=u'resgroup-187805', obj='vim.ResourcePool:resgroup-187805'), obj='vim.ClusterComputeResource:domain-c187804', name='MR-Munich-CL50', id=u'domain-c187804')_
Where clearly the host was assigned to cluster, the method returned _None_.