### PR TITLE
Function for fetching VM data

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -178,10 +178,10 @@ node_types:
         description: |
           Force delete vm for external resource
         default: false
-      ignore_state_changes:
+      enable_start_vm:
         description: |
-          Whether to ignore start action.
-        default: false
+          Enable start (power on) operation for VM.
+        default: true
     interfaces:
       cloudify.interfaces.lifecycle:
         start:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -178,6 +178,10 @@ node_types:
         description: |
           Force delete vm for external resource
         default: false
+      ignore_state_changes:
+        description: |
+          Whether to ignore start action.
+        default: false
     interfaces:
       cloudify.interfaces.lifecycle:
         start:

--- a/vsphere_server_plugin/server.py
+++ b/vsphere_server_plugin/server.py
@@ -318,7 +318,7 @@ def start(
         custom_sysprep,
         custom_attributes,
         use_external_resource,
-        ignore_state_changes,
+        enable_start_vm,
         cdrom_image=None,
         ):
     ctx.logger.debug("Checking whether server exists...")
@@ -363,12 +363,12 @@ def start(
             )
     else:
         server_client.update_server(server=server_obj, cdrom_image=cdrom_image)
-        if ignore_state_changes:
-            ctx.logger.info("Server already exists, but will not be powered on as ignore_state_changes is set to true")
-        else:
+        if enable_start_vm:
             ctx.logger.info("Server already exists, powering on.")
             server_client.start_server(server=server_obj)
             ctx.logger.info("Server powered on.")
+        else:
+            ctx.logger.info("Server already exists, but will not be powered on as enable_start_vm is set to false")
         _get_existing_server_details(ctx, server_client, server)
 
 

--- a/vsphere_server_plugin/server.py
+++ b/vsphere_server_plugin/server.py
@@ -318,6 +318,7 @@ def start(
         custom_sysprep,
         custom_attributes,
         use_external_resource,
+        ignore_state_changes,
         cdrom_image=None,
         ):
     ctx.logger.debug("Checking whether server exists...")
@@ -362,9 +363,13 @@ def start(
             )
     else:
         server_client.update_server(server=server_obj, cdrom_image=cdrom_image)
-        ctx.logger.info("Server already exists, powering on.")
-        server_client.start_server(server=server_obj)
-        ctx.logger.info("Server powered on.")
+        if ignore_state_changes:
+            ctx.logger.info("Server already exists, but will not be powered on as ignore_state_changes is set to true")
+        else:
+            ctx.logger.info("Server already exists, powering on.")
+            server_client.start_server(server=server_obj)
+            ctx.logger.info("Server powered on.")
+        _get_existing_server_details(ctx, server_client, server)
 
 
 @op
@@ -759,15 +764,6 @@ def resize(ctx, server_client, server, os_family):
         raise NonRecoverableError(
             "Server resize parameters should be specified.")
 
-@op
-@with_server_client
-def get_existing_server_details(
-        ctx,
-        server_client,
-        server
-        ):
-    _get_existing_server_details(ctx,server_client,server)
-
 
 def _get_existing_server_details(
         ctx,
@@ -776,7 +772,7 @@ def _get_existing_server_details(
         ):
     server_obj = server_client.get_server_by_name(server.get("name"))
     if server_obj is None:
-        raise NonRecoverableError('Have not found preexisting vm')
+        raise NonRecoverableError('Have not found preexisting vm.')
     ctx.instance.runtime_properties[VSPHERE_SERVER_ID] = server_obj.id
     ctx.instance.runtime_properties['name'] = server_obj.name
     ctx.instance.runtime_properties[NETWORKS] = \
@@ -784,6 +780,7 @@ def _get_existing_server_details(
     ctx.instance.runtime_properties['use_existing_resource'] = True
     ctx.instance.runtime_properties['use_external_resource'] = True
     return server_obj
+
 
 def get_vm_name(ctx, server, os_family):
     # VM name may be at most 15 characters for Windows.

--- a/vsphere_server_plugin/server.py
+++ b/vsphere_server_plugin/server.py
@@ -759,6 +759,31 @@ def resize(ctx, server_client, server, os_family):
         raise NonRecoverableError(
             "Server resize parameters should be specified.")
 
+@op
+@with_server_client
+def get_existing_server_details(
+        ctx,
+        server_client,
+        server
+        ):
+    _get_existing_server_details(ctx,server_client,server)
+
+
+def _get_existing_server_details(
+        ctx,
+        server_client,
+        server
+        ):
+    server_obj = server_client.get_server_by_name(server.get("name"))
+    if server_obj is None:
+        raise NonRecoverableError('Have not found preexisting vm')
+    ctx.instance.runtime_properties[VSPHERE_SERVER_ID] = server_obj.id
+    ctx.instance.runtime_properties['name'] = server_obj.name
+    ctx.instance.runtime_properties[NETWORKS] = \
+        server_client.get_vm_networks(server_obj)
+    ctx.instance.runtime_properties['use_existing_resource'] = True
+    ctx.instance.runtime_properties['use_external_resource'] = True
+    return server_obj
 
 def get_vm_name(ctx, server, os_family):
     # VM name may be at most 15 characters for Windows.


### PR DESCRIPTION
Operation can be used in exising VMs for fetching VM data (ie. its ID or networks).
        interfaces:
            cloudify.interfaces.lifecycle:
                start: 
                    implementation: vsphere.vsphere_server_plugin.server.get_existing_server_details