### PR TITLE
Add cloudbase-init example

### DIFF
--- a/system_tests/resources/windows/cloud-init.yaml
+++ b/system_tests/resources/windows/cloud-init.yaml
@@ -1,0 +1,277 @@
+# download ovf from https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/
+# install https://github.com/cloudbase/cloudbase-init
+
+tosca_definitions_version: cloudify_dsl_1_3
+
+imports:
+  - https://cloudify.co/spec/cloudify/4.6/types.yaml
+  - plugin:cloudify-vsphere-plugin
+  - plugin:cloudify-utilities-plugin
+
+inputs:
+
+  vcenter_user:
+    type: string
+
+  vcenter_password:
+    type: string
+
+  vcenter_ip:
+    type: string
+
+  vcenter_port:
+    type: string
+    default: 443
+
+  vcenter_datacenter:
+    type: string
+    description: >
+       vcenter datacenter
+    default: Datacenter
+
+  vcenter_resource_pool:
+    description: >
+      Resource pool name
+    default: Resources
+
+  vsphere_auto_placement:
+    type: string
+    default: true
+
+  template_name:
+    type: string
+    description: >
+      "Windows with CloudBase template name"
+    default: "WinCheckCloudInit"
+
+  vcenter_datastore:
+    type: string
+    description: >
+      vcenter datastore
+    default: datastore1
+
+  allowed_hosts:
+    default: []
+
+  allowed_clusters:
+    default: []
+
+  allowed_datastores:
+    default: []
+
+  custom_attributes:
+    default:
+      key: value
+
+  # active directory
+  cloudify_local_user:
+    description: >
+      New local user
+    default: cloudify
+
+  cloudify_password:
+    description: >
+      Password for new create cloudify local user
+    default: StrongPassw0rd
+
+  cloudify_dc_ip:
+    description: >
+      Active directory ip
+
+  cloudify_dc_name:
+    description: >
+      Active directory name
+
+  cloudify_dc_password:
+    description: >
+      Active directory password
+
+  agent_user:
+    description: >
+      Agent user name
+
+  agent_password:
+    description: >
+      Agent user password
+
+###############################################################################
+#  DSL section
+###############################################################################
+dsl_definitions:
+
+  connection_config: &connection_config
+    username: { get_input: vcenter_user }
+    password: {get_input: vcenter_password }
+    host: { get_input: vcenter_ip }
+    port: { get_input: vcenter_port }
+    datacenter_name: {get_input: vcenter_datacenter }
+    resource_pool_name: { get_input: vcenter_resource_pool }
+    auto_placement: { get_input: vsphere_auto_placement }
+    allow_insecure: true
+
+node_types:
+
+  host:
+    derived_from: cloudify.vsphere.nodes.Server
+    properties:
+      vm_folder:
+        default: vm
+      connection_config:
+        default: *connection_config
+      os_family:
+        default: other
+      allowed_hosts:
+        default: { get_input: allowed_hosts }
+      allowed_clusters:
+        default: { get_input: allowed_clusters }
+      allowed_datastores:
+        default: { get_input: allowed_datastores }
+      postpone_delete_networks:
+        default: true
+      custom_attributes:
+        default: { get_input: custom_attributes }
+      server:
+        default:
+          name: other_vm
+          template: { get_input: template_name }
+          cpus: 1
+          memory: 2048
+      agent_config:
+        default:
+          install_method: none
+      networking:
+        default:
+          connect_networks:
+            - name: Internal
+              switch_distributed: false
+              management: true
+
+node_templates:
+
+  meta_data_init:
+    type: cloudify.nodes.CloudInit.CloudConfig
+    properties:
+      resource_config:
+        hostname: cloudbase.dev
+        name: cloudbase
+        instance-id: cloudbase
+
+  vendor_data_init:
+    type: cloudify.nodes.CloudInit.CloudConfig
+    properties:
+      resource_config: {}
+
+  user_data_init:
+    type: cloudify.nodes.CloudInit.CloudConfig
+    properties:
+      resource_config:
+        users:
+          - name: { get_input: cloudify_local_user }
+            gecos: 'Cloudify Agent User'
+            primary_group: Users
+            groups: Administrators
+            passwd: { get_input: cloudify_password }
+            inactive: False
+            expiredate: "2020-10-01"
+        write_files:
+        - content:
+            resource_type: file_resource
+            resource_name: scripts/domain.ps1
+            template_variables:
+              DC_IP: { get_input: cloudify_dc_ip }
+              DC_NAME: { get_input: cloudify_dc_name }
+              DC_PASSWORD: { get_input: cloudify_dc_password }
+          path: C:\domain.ps1
+          permissions: '0644'
+        runcmd:
+        - 'powershell.exe C:\\domain.ps1'
+
+  cloud_init_image:
+    type: cloudify.vsphere.nodes.CloudInitISO
+    properties:
+      connection_config: *connection_config
+      datacenter_name: { get_input: vcenter_datacenter }
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          inputs:
+            allowed_datastores:
+            - { get_input: vcenter_datastore }
+            vol_ident: config-2
+            files:
+              # meta
+              "openstack/2012-08-10/meta_data.json": { get_attribute: [meta_data_init, json_config ] }
+              "openstack/2013-04-04/meta_data.json": { get_attribute: [meta_data_init, json_config ] }
+              "openstack/2013-10-17/meta_data.json": { get_attribute: [meta_data_init, json_config ] }
+              "openstack/2015-10-15/meta_data.json": { get_attribute: [meta_data_init, json_config ] }
+              "openstack/latest/meta_data.json": { get_attribute: [meta_data_init, json_config ] }
+              "ec2/2009-04-04/meta-data.json": { get_attribute: [meta_data_init, json_config ] }
+              "ec2/latest/meta-data.json": { get_attribute: [meta_data_init, json_config ] }
+              # vendor
+              "openstack/latest/vendor_data.json": { get_attribute: [vendor_data_init, json_config ] }
+              "openstack/2013-10-17/vendor_data.json": { get_attribute: [vendor_data_init, json_config ] }
+              "openstack/2015-10-15/vendor_data.json": { get_attribute: [vendor_data_init, json_config ] }
+              # https://cloudbase-init.readthedocs.io/en/latest/userdata.html
+              "openstack/2012-08-10/user_data": { get_attribute: [user_data_init, cloud_config ] }
+              "openstack/2013-04-04/user_data": { get_attribute: [user_data_init, cloud_config ] }
+              "openstack/2013-10-17/user_data": { get_attribute: [user_data_init, cloud_config ] }
+              "openstack/2015-10-15/user_data": { get_attribute: [user_data_init, cloud_config ] }
+              "openstack/latest/user_data": { get_attribute: [user_data_init, cloud_config ] }
+              "ec2/2009-04-04/user-data": { get_attribute: [user_data_init, cloud_config ] }
+              "ec2/latest/user-data": { get_attribute: [user_data_init, cloud_config ] }
+    relationships:
+    - target: user_data_init
+      type: cloudify.relationships.depends_on
+    - target: meta_data_init
+      type: cloudify.relationships.depends_on
+    - target: vendor_data_init
+      type: cloudify.relationships.depends_on
+
+  network:
+    type: cloudify.vsphere.nodes.Network
+    properties:
+      use_external_resource: true
+      network:
+        name: Internal
+        switch_distributed: false
+      connection_config: *connection_config
+
+  vm_stopped:
+    type: host
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        create:
+          implementation: vsphere.vsphere_server_plugin.server.start
+          inputs:
+            enable_start_vm: false
+        start:
+          implementation: vsphere.vsphere_server_plugin.server.resize_server
+          inputs:
+            cpus: 2
+            memory: 2048
+    relationships:
+    - target: network
+      type: cloudify.relationships.depends_on
+
+  vm_base:
+    type: host
+    properties:
+      use_external_resource: true
+      os_family: windows
+      agent_config:
+        install_method: remote
+        transport: ntlm
+        user: { get_input: agent_user }
+        password: { get_input: agent_password }
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        start:
+          inputs:
+            cdrom_image: { get_attribute: [cloud_init_image, storage_image ] }
+            server:
+              name: { get_attribute: [vm_stopped, name] }
+    relationships:
+    - target: cloud_init_image
+      type: cloudify.relationships.depends_on
+    - target: vm_stopped
+      type: cloudify.relationships.depends_on

--- a/system_tests/resources/windows/scripts/domain.ps1
+++ b/system_tests/resources/windows/scripts/domain.ps1
@@ -1,0 +1,29 @@
+<#
+    .SYNOPSIS
+    This script will joing computer to domain
+    .NOTES
+    You need a Windows Server 2016 for this script to work.
+#>
+
+winrm quickconfig -q
+winrm set winrm/config              '@{MaxTimeoutms="1800000"}'
+winrm set winrm/config/winrs        '@{MaxMemoryPerShellMB="300"}'
+winrm set winrm/config/service      '@{AllowUnencrypted="true"}'
+winrm set winrm/config/service/auth '@{Basic="true"}'
+
+# Requires -Version 3
+# Requires -RunAsAdministrator
+$dc_ip = "{{DC_IP}}"
+$Domain = "{{DC_NAME}}"
+$dc_admin = $Domain + "\Administrator"
+$dc_password = ConvertTo-SecureString "{{DC_PASSWORD}}" -AsPlainText -Force
+$creds = New-Object System.Management.Automation.PSCredential ($dc_admin, $dc_password)
+
+# Configure DNS
+$netid = Get-WmiObject -Class Win32_NetworkAdapter | select netconnectionid | foreach {$_.netconnectionid}
+netsh interface ipv4 add dnsserver $netid $dc_ip index=1
+$regPath = "HKLM:\System\CurrentControlSet\Services\TCPIP\Parameters"
+Set-ItemProperty -Path $regPath -Name "SearchList" -Value $Domain -Confirm:$false
+
+# Try to add to domain
+Add-Computer -DomainName $Domain -Credential $creds -Restart -Force -Confirm:$false

--- a/tox.ini
+++ b/tox.ini
@@ -108,6 +108,7 @@ commands =
     cfy blueprint validate system_tests/resources/network/existing-network-blueprint.yaml
     cfy blueprint validate system_tests/resources/solaris/content_library.yaml
     cfy blueprint validate system_tests/resources/windows/windows_custom_sysprep-blueprint.yaml
+    cfy blueprint validate system_tests/resources/windows/cloud-init.yaml
     cfy blueprint validate system_tests/resources/windows/no_password-blueprint.yaml
     cfy blueprint validate system_tests/resources/windows/windows_sysprep_and_password-blueprint.yaml
     cfy blueprint validate system_tests/resources/windows/agent_config_password_and_default_timezone-blueprint.yaml


### PR DESCRIPTION
Add cloudbase-init example for windows. 

Contains example for:
* add new user as part of cloudinit
* write file to fs as part of cloudinit
* run script as part of cloudinit
* attach VM to windows Active Directory
* install agent as domain user